### PR TITLE
Add the ability to exit using ctr+c

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,3 @@ To run, simply enter:
     python cam_server.py
 
 in your Linux terminal.
-
-Right now, it is not possible to stop the server without sending a SIGTERM.  I am attempting to fix this.

--- a/cam_server.py
+++ b/cam_server.py
@@ -136,5 +136,3 @@ if __name__ == "__main__":
     except:
         print("exiting")
         exit(0)
-
-    

--- a/cam_server.py
+++ b/cam_server.py
@@ -9,6 +9,7 @@ import gi
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst, GObject
 import json
+import signal
 
 sockets = []
 
@@ -95,6 +96,11 @@ def start_server(app):
     http_server.listen(8888)
     tornado.ioloop.IOLoop.instance().start()
 
+def signal_handler(signum, frame):
+    print("Interrupt caught")
+    tornado.ioloop.IOLoop.instance().stop()
+    server_thread.stop()
+
 if __name__ == "__main__":
 
     application = tornado.web.Application([
@@ -115,9 +121,20 @@ if __name__ == "__main__":
     server_thread = threading.Thread(target=start_server, args=[application])
     server_thread.start()
 
+    # or you can use a custom handler,
+    # in which case recv will fail with EINTR
+    print("registering sigint")
+    signal.signal(signal.SIGINT, signal_handler)
+
     try:
+        print("gst_thread_join")
         gst_thread.join()
-        server_thread.join()
+        print("Pausing so that thread doesn't exit")
+        while(1):
+            time.sleep(1)
+
     except:
         print("exiting")
         exit(0)
+
+    


### PR DESCRIPTION
This bug was caused by server_thread.join() this blocked the main thread until the server thread exited. The server thread doesn't exit on it's own so the main thread never had a chance to catch the keyboard exception.

After deleting the blocking function call and adding a signal handler callback, everything works.
